### PR TITLE
CI: only fail audit for level=high

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,8 @@ jobs:
     - uses: actions/checkout@v6.0.2
     - name: npm audit
       run: |
-        npm audit
+        # we currently only have dev dependencies, so unlikely they are a real problem
+        npm audit --audit-level=high
 
   unit-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Failing the CI is supposed to be a last line of defence, but we run node stuff only with trusted input, so most vulnerabilities will not be a problem anyway.

Dependabot hopefully finds actual problems and suggests updates.